### PR TITLE
Add MudBlazor pages and backend services

### DIFF
--- a/BlazorApp1/BlazorApp1.Client/BlazorApp1.Client.csproj
+++ b/BlazorApp1/BlazorApp1.Client/BlazorApp1.Client.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.17" />
+    <PackageReference Include="MudBlazor" Version="8.8.0" />
   </ItemGroup>
 
 </Project>

--- a/BlazorApp1/BlazorApp1.Client/Layout/NavMenu.razor
+++ b/BlazorApp1/BlazorApp1.Client/Layout/NavMenu.razor
@@ -25,6 +25,16 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="info">
+                <span class="bi bi-info-circle" aria-hidden="true"></span> Информация
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="search">
+                <span class="bi bi-search" aria-hidden="true"></span> Поиск
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/BlazorApp1/BlazorApp1.Client/Models/QueueInfo.cs
+++ b/BlazorApp1/BlazorApp1.Client/Models/QueueInfo.cs
@@ -1,0 +1,8 @@
+namespace BlazorApp1.Client.Models;
+
+public class QueueInfo
+{
+    public string QueueNumber { get; set; } = string.Empty;
+    public string MfcNumber { get; set; } = string.Empty;
+    public string OrderNumber { get; set; } = string.Empty;
+}

--- a/BlazorApp1/BlazorApp1.Client/Pages/Info.razor
+++ b/BlazorApp1/BlazorApp1.Client/Pages/Info.razor
@@ -1,0 +1,7 @@
+@page "/info"
+
+<MudCard Class="pa-4">
+    <MudText Typo="Typo.h5">Общая информация</MudText>
+    <MudText>Это демонстрационное приложение для поиска данных по номерам распоряжений.</MudText>
+    <MudText>Для загрузки Excel используйте нашего <MudLink Href="https://t.me/example_bot" Target="_blank">Telegram-бота</MudLink>.</MudText>
+</MudCard>

--- a/BlazorApp1/BlazorApp1.Client/Pages/Search.razor
+++ b/BlazorApp1/BlazorApp1.Client/Pages/Search.razor
@@ -1,0 +1,69 @@
+@page "/search"
+
+@inject HttpClient Http
+@using BlazorApp1.Client.Models
+@using MudBlazor
+
+<MudCard Class="pa-4">
+    <MudTextField @bind-Value="OrderNumber" Label="Номер распоряжения" Variant="Variant.Outlined" Class="mb-2" />
+    <MudTextField @bind-Value="MfcNumber" Label="Номер МФЦ" Variant="Variant.Outlined" Class="mb-2" />
+    <MudButton Variant="Variant.Filled" OnClick="SearchAsync">Найти</MudButton>
+</MudCard>
+
+@if (Results?.Any() == true)
+{
+    <MudTable Items="Results">
+        <HeaderContent>
+            <MudTh>Номер очереди</MudTh>
+            <MudTh>Номер МФЦ</MudTh>
+            <MudTh>Номер распоряжения</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Номер очереди">@context.QueueNumber</MudTd>
+            <MudTd DataLabel="Номер МФЦ">@context.MfcNumber</MudTd>
+            <MudTd DataLabel="Номер распоряжения">@context.OrderNumber</MudTd>
+        </RowTemplate>
+    </MudTable>
+}
+
+<MudDialog @bind-IsVisible="ShowDateDialog">
+    <DialogContent>
+        <MudList T="string">
+            @foreach (var item in DateOptions)
+            {
+                <MudListItem T="string" OnClick="() => SelectDate(item)">@item</MudListItem>
+            }
+        </MudList>
+    </DialogContent>
+</MudDialog>
+
+@code {
+    private string OrderNumber { get; set; } = string.Empty;
+    private string MfcNumber { get; set; } = string.Empty;
+    private List<QueueInfo>? Results;
+
+    private bool ShowDateDialog;
+    private List<string> DateOptions = new();
+
+    private async Task SearchAsync()
+    {
+        if (string.IsNullOrWhiteSpace(OrderNumber)) return;
+        var url = $"api/search?orderNumber={Uri.EscapeDataString(OrderNumber)}";
+        if (!string.IsNullOrWhiteSpace(MfcNumber))
+            url += $"&mfcNumber={Uri.EscapeDataString(MfcNumber)}";
+        Results = await Http.GetFromJsonAsync<List<QueueInfo>>(url);
+        var dates = Results?.Select(r => r.OrderNumber).Distinct().ToList();
+        if (dates != null && dates.Count > 1)
+        {
+            DateOptions = dates;
+            ShowDateDialog = true;
+        }
+    }
+
+    private void SelectDate(string date)
+    {
+        Results = Results?.Where(r => r.OrderNumber == date).ToList();
+        ShowDateDialog = false;
+        StateHasChanged();
+    }
+}

--- a/BlazorApp1/BlazorApp1.Client/Program.cs
+++ b/BlazorApp1/BlazorApp1.Client/Program.cs
@@ -1,5 +1,9 @@
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using MudBlazor.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+builder.Services.AddMudServices();
+builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new(builder.HostEnvironment.BaseAddress) });
 
 await builder.Build().RunAsync();

--- a/BlazorApp1/BlazorApp1.Client/_Imports.razor
+++ b/BlazorApp1/BlazorApp1.Client/_Imports.razor
@@ -7,3 +7,4 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 @using BlazorApp1.Client
+@using MudBlazor

--- a/BlazorApp1/BlazorApp1/BlazorApp1.csproj
+++ b/BlazorApp1/BlazorApp1/BlazorApp1.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ClosedXML" Version="0.105.0" />
     <ProjectReference Include="..\BlazorApp1.Client\BlazorApp1.Client.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.17" />
   </ItemGroup>

--- a/BlazorApp1/BlazorApp1/Components/App.razor
+++ b/BlazorApp1/BlazorApp1/Components/App.razor
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="bootstrap/bootstrap.min.css" />
     <link rel="stylesheet" href="app.css" />
     <link rel="stylesheet" href="BlazorApp1.styles.css" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <HeadOutlet @rendermode="InteractiveAuto" />
 </head>
@@ -15,6 +16,7 @@
 <body>
     <Routes @rendermode="InteractiveAuto" />
     <script src="_framework/blazor.web.js"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
 </body>
 
 </html>

--- a/BlazorApp1/BlazorApp1/Controllers/ExcelController.cs
+++ b/BlazorApp1/BlazorApp1/Controllers/ExcelController.cs
@@ -1,0 +1,32 @@
+using BlazorApp1.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BlazorApp1.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ExcelController : ControllerBase
+{
+    private readonly ExcelDataService _excel;
+
+    public ExcelController(ExcelDataService excel)
+    {
+        _excel = excel;
+    }
+
+    [HttpPost("validate-excel")]
+    public async Task<IActionResult> Validate([FromForm] IFormFile file)
+    {
+        if (file == null || file.Length == 0)
+        {
+            return BadRequest("File not provided");
+        }
+        using var stream = file.OpenReadStream();
+        var ok = await _excel.LoadAsync(stream);
+        if (!ok)
+        {
+            return BadRequest("Ошибка: файл содержит персональные данные");
+        }
+        return Ok();
+    }
+}

--- a/BlazorApp1/BlazorApp1/Controllers/SearchController.cs
+++ b/BlazorApp1/BlazorApp1/Controllers/SearchController.cs
@@ -1,0 +1,23 @@
+using BlazorApp1.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BlazorApp1.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SearchController : ControllerBase
+{
+    private readonly ExcelDataService _excel;
+
+    public SearchController(ExcelDataService excel)
+    {
+        _excel = excel;
+    }
+
+    [HttpGet]
+    public IActionResult Search([FromQuery] string orderNumber, [FromQuery] string? mfcNumber)
+    {
+        var records = _excel.Search(orderNumber, mfcNumber);
+        return Ok(records);
+    }
+}

--- a/BlazorApp1/BlazorApp1/Models/QueueInfo.cs
+++ b/BlazorApp1/BlazorApp1/Models/QueueInfo.cs
@@ -1,0 +1,8 @@
+namespace BlazorApp1.Models;
+
+public class QueueInfo
+{
+    public string QueueNumber { get; set; } = string.Empty;
+    public string MfcNumber { get; set; } = string.Empty;
+    public string OrderNumber { get; set; } = string.Empty; // with date
+}

--- a/BlazorApp1/BlazorApp1/Program.cs
+++ b/BlazorApp1/BlazorApp1/Program.cs
@@ -1,9 +1,13 @@
 using BlazorApp1.Client.Pages;
 using BlazorApp1.Components;
+using BlazorApp1.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+builder.Services.AddControllers();
+builder.Services.AddSingleton<ExcelDataService>();
+
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents()
     .AddInteractiveWebAssemblyComponents();
@@ -22,6 +26,8 @@ else
 
 app.UseStaticFiles();
 app.UseAntiforgery();
+
+app.MapControllers();
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode()

--- a/BlazorApp1/BlazorApp1/Services/ExcelDataService.cs
+++ b/BlazorApp1/BlazorApp1/Services/ExcelDataService.cs
@@ -1,0 +1,66 @@
+using System.Text.RegularExpressions;
+using BlazorApp1.Models;
+using ClosedXML.Excel;
+
+namespace BlazorApp1.Services;
+
+public class ExcelDataService
+{
+    private readonly ILogger<ExcelDataService> _logger;
+    private readonly List<QueueInfo> _records = new();
+
+    public ExcelDataService(ILogger<ExcelDataService> logger)
+    {
+        _logger = logger;
+    }
+
+    public IReadOnlyList<QueueInfo> Records => _records;
+
+    public async Task<bool> LoadAsync(Stream stream)
+    {
+        _records.Clear();
+        using var workbook = new XLWorkbook(stream);
+        var ws = workbook.Worksheets.First();
+        foreach (var row in ws.RowsUsed().Skip(1))
+        {
+            var queue = row.Cell(1).GetString();
+            var mfc = row.Cell(2).GetString();
+            var order = row.Cell(3).GetString();
+            if (ContainsPersonalData(queue) || ContainsPersonalData(mfc) || ContainsPersonalData(order))
+            {
+                return false;
+            }
+            _records.Add(new QueueInfo
+            {
+                QueueNumber = queue,
+                MfcNumber = mfc,
+                OrderNumber = order
+            });
+        }
+        return true;
+    }
+
+    private static readonly Regex[] PersonalDataPatterns =
+    {
+        new(@"\b\d{3}-\d{3}-\d{3} \d{2}\b", RegexOptions.Compiled), // SNILS
+        new(@"\b\d{11}\b", RegexOptions.Compiled), // INN etc
+        new(@"(?i)паспорт", RegexOptions.Compiled),
+        new(@"[А-ЯЁ][а-яё]+\s+[А-ЯЁ][а-яё]+\s+[А-ЯЁ][а-яё]+", RegexOptions.Compiled)
+    };
+
+    private static bool ContainsPersonalData(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        return PersonalDataPatterns.Any(p => p.IsMatch(value));
+    }
+
+    public IEnumerable<QueueInfo> Search(string orderNumber, string? mfcNumber)
+    {
+        var matches = _records.Where(r => r.OrderNumber.Contains(orderNumber, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrEmpty(mfcNumber))
+        {
+            matches = matches.Where(r => r.MfcNumber.Contains(mfcNumber, StringComparison.OrdinalIgnoreCase));
+        }
+        return matches.ToList();
+    }
+}


### PR DESCRIPTION
## Summary
- add MudBlazor package and configure client for MudBlazor
- create "Общая информация" page with links
- create search page with queue search logic and date dialog
- add Excel service with personal data validation using regex
- expose API controllers for search and Excel validation
- register controllers and services in Program.cs and include MudBlazor assets

## Testing
- `dotnet build BlazorApp1.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686188b279f48323a75bcf91db0f48f8