### PR TITLE
Enable detailed errors in Blazor app

### DIFF
--- a/BlazorApp1/BlazorApp1/Program.cs
+++ b/BlazorApp1/BlazorApp1/Program.cs
@@ -9,7 +9,10 @@ builder.Services.AddControllers();
 builder.Services.AddSingleton<ExcelDataService>();
 
 builder.Services.AddRazorComponents()
-    .AddInteractiveServerComponents()
+    .AddInteractiveServerComponents(options =>
+    {
+        options.DetailedErrors = true;
+    })
     .AddInteractiveWebAssemblyComponents();
 
 var app = builder.Build();

--- a/BlazorApp1/BlazorApp1/appsettings.Development.json
+++ b/BlazorApp1/BlazorApp1/appsettings.Development.json
@@ -4,5 +4,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "DetailedErrors": true
 }


### PR DESCRIPTION
## Summary
- enable detailed circuit error reporting in `Program.cs`
- turn on `DetailedErrors` in the development settings

## Testing
- `dotnet restore BlazorApp1.sln`
- `dotnet build BlazorApp1.sln`


------
https://chatgpt.com/codex/tasks/task_e_68618a60e4348323ba2a694126d15cb8