### PR TITLE
Fix missing HttpClient registration

### DIFF
--- a/BlazorApp1/BlazorApp1/Program.cs
+++ b/BlazorApp1/BlazorApp1/Program.cs
@@ -1,12 +1,21 @@
 using BlazorApp1.Client.Pages;
 using BlazorApp1.Components;
 using BlazorApp1.Services;
+using Microsoft.AspNetCore.Components;
+using System.Net.Http;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllers();
 builder.Services.AddSingleton<ExcelDataService>();
+
+// Register HttpClient for server-side components
+builder.Services.AddScoped(sp =>
+{
+    var navigationManager = sp.GetRequiredService<NavigationManager>();
+    return new HttpClient { BaseAddress = new Uri(navigationManager.BaseUri) };
+});
 
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents(options =>


### PR DESCRIPTION
## Summary
- add Microsoft.AspNetCore.Components and System.Net.Http using statements
- register HttpClient in server Program.cs so pages can inject it

## Testing
- `dotnet build BlazorApp1.sln`

------
https://chatgpt.com/codex/tasks/task_e_68618fa9619883239dc82e768c8880e7