### PR TITLE
Reset Blazor theme to default

### DIFF
--- a/BlazorApp1/BlazorApp1/wwwroot/app.css
+++ b/BlazorApp1/BlazorApp1/wwwroot/app.css
@@ -1,6 +1,5 @@
 html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-    background-color: #ADD8E6;
 }
 
 a, .btn-link {


### PR DESCRIPTION
## Summary
- revert the `app.css` body background color to match the default Blazor style

## Testing
- `dotnet build BlazorApp1.sln`


------
https://chatgpt.com/codex/tasks/task_e_6861967777c083238459bacb264b31dd