### PR TITLE
Enable MFC number search

### DIFF
--- a/BlazorApp1/BlazorApp1.Client/Pages/Search.razor
+++ b/BlazorApp1/BlazorApp1.Client/Pages/Search.razor
@@ -82,14 +82,19 @@
     private async Task SearchAsync()
     {
         ErrorMessage = string.Empty;
-        if (string.IsNullOrWhiteSpace(OrderNumber))
+        if (string.IsNullOrWhiteSpace(OrderNumber) && string.IsNullOrWhiteSpace(MfcNumber))
         {
-            ErrorMessage = "Введите номер распоряжения";
+            ErrorMessage = "Введите номер распоряжения или МФЦ";
             return;
         }
-        var url = $"api/search?orderNumber={Uri.EscapeDataString(OrderNumber)}";
+        var url = "api/search?";
+        if (!string.IsNullOrWhiteSpace(OrderNumber))
+            url += $"orderNumber={Uri.EscapeDataString(OrderNumber)}";
         if (!string.IsNullOrWhiteSpace(MfcNumber))
-            url += $"&mfcNumber={Uri.EscapeDataString(MfcNumber)}";
+        {
+            if (!url.EndsWith("?")) url += "&";
+            url += $"mfcNumber={Uri.EscapeDataString(MfcNumber)}";
+        }
         Results = await Http.GetFromJsonAsync<List<QueueInfo>>(url);
         if (Results == null || Results.Count == 0)
         {

--- a/BlazorApp1/BlazorApp1/Controllers/SearchController.cs
+++ b/BlazorApp1/BlazorApp1/Controllers/SearchController.cs
@@ -15,7 +15,7 @@ public class SearchController : ControllerBase
     }
 
     [HttpGet]
-    public IActionResult Search([FromQuery] string orderNumber, [FromQuery] string? mfcNumber)
+    public IActionResult Search([FromQuery] string? orderNumber, [FromQuery] string? mfcNumber)
     {
         var records = _excel.Search(orderNumber, mfcNumber);
         return Ok(records);

--- a/BlazorApp1/BlazorApp1/Services/ExcelDataService.cs
+++ b/BlazorApp1/BlazorApp1/Services/ExcelDataService.cs
@@ -54,13 +54,25 @@ public class ExcelDataService
         return PersonalDataPatterns.Any(p => p.IsMatch(value));
     }
 
-    public IEnumerable<QueueInfo> Search(string orderNumber, string? mfcNumber)
+    public IEnumerable<QueueInfo> Search(string? orderNumber, string? mfcNumber)
     {
-        var matches = _records.Where(r => r.OrderNumber.Contains(orderNumber, StringComparison.OrdinalIgnoreCase));
-        if (!string.IsNullOrEmpty(mfcNumber))
+        IEnumerable<QueueInfo> matches = _records;
+
+        if (!string.IsNullOrWhiteSpace(orderNumber))
+        {
+            matches = matches.Where(r => r.OrderNumber.Contains(orderNumber, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrWhiteSpace(mfcNumber))
         {
             matches = matches.Where(r => r.MfcNumber.Contains(mfcNumber, StringComparison.OrdinalIgnoreCase));
         }
+
+        if (string.IsNullOrWhiteSpace(orderNumber) && string.IsNullOrWhiteSpace(mfcNumber))
+        {
+            return Enumerable.Empty<QueueInfo>();
+        }
+
         return matches.ToList();
     }
 }


### PR DESCRIPTION
## Summary
- allow searching using only MFC number in `ExcelDataService`
- make order number optional in controller
- update Search page to build request when only MFC number is provided

## Testing
- `dotnet build BlazorApp1.sln`

------
https://chatgpt.com/codex/tasks/task_e_68619e533690832381d5213a5fffab8a