### PR TITLE
Persist Excel file for reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,5 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+# Uploaded Excel file
+/data/

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ This ASP.NET server hosts a Telegram bot that accepts Excel files.
 dotnet run --project BlazorApp1/BlazorApp1 -c Release
 ```
 
-When you send an Excel file to the bot, it checks the file for personal data patterns and responds with a confirmation or an error message.
+When you send an Excel file to the bot, it checks the file for personal data patterns and responds with a confirmation or an error message. The last valid file is stored on disk and loaded on server start so searches continue to work after a restart.


### PR DESCRIPTION
## Summary
- persist uploaded Excel file on disk so it can be loaded on startup
- document this behaviour in the README
- ignore the data folder

## Testing
- `dotnet build BlazorApp1.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6861a31ca8548323804e1fc2b9b5cdf0