### PR TITLE
Add Telegram bot settings to config

### DIFF
--- a/BlazorApp1/BlazorApp1/Services/TelegramBotService.cs
+++ b/BlazorApp1/BlazorApp1/Services/TelegramBotService.cs
@@ -20,7 +20,9 @@ public class TelegramBotService : BackgroundService
 
     protected override Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var token = _config["TELEGRAM_BOT_TOKEN"] ?? Environment.GetEnvironmentVariable("TELEGRAM_BOT_TOKEN");
+        var token = _config["TelegramBot:Token"]
+                    ?? _config["TELEGRAM_BOT_TOKEN"]
+                    ?? Environment.GetEnvironmentVariable("TELEGRAM_BOT_TOKEN");
         if (string.IsNullOrWhiteSpace(token))
         {
             _logger.LogInformation("Telegram bot token not provided; bot disabled");

--- a/BlazorApp1/BlazorApp1/appsettings.json
+++ b/BlazorApp1/BlazorApp1/appsettings.json
@@ -6,4 +6,8 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "TelegramBot": {
+    "Token": "YOUR_TELEGRAM_BOT_TOKEN"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This ASP.NET server hosts a Telegram bot that accepts Excel files.
 ## Running
 
 1. Obtain a Telegram bot token from [@BotFather](https://t.me/BotFather).
-2. Set the environment variable `TELEGRAM_BOT_TOKEN` with the token value.
+2. Provide the token using either the `TELEGRAM_BOT_TOKEN` environment variable
+   or by placing it in `appsettings.json` under `TelegramBot:Token`.
 3. Build and run the server:
 
 ```bash


### PR DESCRIPTION
## Summary
- add Telegram bot configuration section
- update service to read token from `TelegramBot:Token`
- document new configuration method

## Testing
- `dotnet build BlazorApp1.sln`

------
https://chatgpt.com/codex/tasks/task_e_68623b7a1d4c8323ad013ecf3aa1049e