### PR TITLE
Fix search to require exact MFC and order number match

### DIFF
--- a/BlazorApp1/BlazorApp1/Services/ExcelDataService.cs
+++ b/BlazorApp1/BlazorApp1/Services/ExcelDataService.cs
@@ -104,12 +104,12 @@ public class ExcelDataService
 
         if (!string.IsNullOrWhiteSpace(orderNumber))
         {
-            matches = matches.Where(r => r.OrderNumber.Contains(orderNumber, StringComparison.OrdinalIgnoreCase));
+            matches = matches.Where(r => string.Equals(r.OrderNumber, orderNumber, StringComparison.OrdinalIgnoreCase));
         }
 
         if (!string.IsNullOrWhiteSpace(mfcNumber))
         {
-            matches = matches.Where(r => r.MfcNumber.Contains(mfcNumber, StringComparison.OrdinalIgnoreCase));
+            matches = matches.Where(r => string.Equals(r.MfcNumber, mfcNumber, StringComparison.OrdinalIgnoreCase));
         }
 
         if (string.IsNullOrWhiteSpace(orderNumber) && string.IsNullOrWhiteSpace(mfcNumber))


### PR DESCRIPTION
## Summary
- ensure Search method matches exact MFC and order numbers
- check .NET 8 and build the project

## Testing
- `dotnet restore BlazorApp1.sln`
- `dotnet build BlazorApp1.sln`


------
https://chatgpt.com/codex/tasks/task_e_686243605c8c8323979ecc8374637d8e