### PR TITLE
Add Docker setup with HTTPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY BlazorApp1/BlazorApp1.csproj BlazorApp1/
+COPY BlazorApp1/BlazorApp1.Client/BlazorApp1.Client.csproj BlazorApp1/BlazorApp1.Client/
+RUN dotnet restore BlazorApp1/BlazorApp1.csproj
+COPY . .
+WORKDIR /src/BlazorApp1/BlazorApp1
+RUN dotnet publish BlazorApp1.csproj -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+EXPOSE 80
+EXPOSE 443
+ENTRYPOINT ["dotnet", "BlazorApp1.dll"]

--- a/README.md
+++ b/README.md
@@ -20,3 +20,18 @@ When you send an Excel file to the bot, it checks the file for personal data pat
 The server uses response compression and ships only minified client assets to reduce bandwidth usage.
 
 When you send an Excel file to the bot, it checks the file for personal data patterns and responds with a confirmation or an error message. The last valid file is stored on disk and loaded on server start so searches continue to work after a restart.
+
+## Docker deployment with HTTPS
+
+A `Dockerfile` and `docker-compose.yml` are provided to run the application with
+automatic HTTPS certificates from Let's Encrypt. Set the `VIRTUAL_HOST`,
+`LETSENCRYPT_HOST` and `LETSENCRYPT_EMAIL` environment variables in
+`docker-compose.yml` to your domain and email before starting:
+
+```bash
+docker compose up -d
+```
+
+The `nginx-proxy` and `acme-companion` containers handle HTTPS termination and
+certificate renewal. The application itself listens on port 80 inside the Docker
+network.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3'
+services:
+  app:
+    build: .
+    environment:
+      - ASPNETCORE_URLS=http://+:80
+      - VIRTUAL_HOST=example.com
+      - LETSENCRYPT_HOST=example.com
+      - LETSENCRYPT_EMAIL=admin@example.com
+    volumes:
+      - app_data:/app/data
+    restart: unless-stopped
+
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy:alpine
+    container_name: nginx-proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - certs:/etc/nginx/certs:rw
+      - vhost:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    restart: unless-stopped
+
+  acme-companion:
+    image: nginxproxy/acme-companion
+    environment:
+      - DEFAULT_EMAIL=admin@example.com
+    volumes:
+      - certs:/etc/nginx/certs:rw
+      - acme:/etc/acme.sh
+      - vhost:/etc/nginx/vhost.d
+      - html:/usr/share/nginx/html
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      - nginx-proxy
+    restart: unless-stopped
+
+volumes:
+  app_data:
+  certs:
+  vhost:
+  html:
+  acme:


### PR DESCRIPTION
## Summary
- containerize BlazorApp1 with a Dockerfile
- add docker-compose configuration using `nginx-proxy` and `acme-companion`
- document Docker deployment with automatic Let's Encrypt certificates

## Testing
- `dotnet build BlazorApp1.sln`
- `docker build -t blazorapp .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68624a679aa08323a51157030e4db30d