### PR TITLE
Fix Dockerfile path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Build stage
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
-COPY BlazorApp1/BlazorApp1.csproj BlazorApp1/
+COPY BlazorApp1/BlazorApp1/BlazorApp1.csproj BlazorApp1/BlazorApp1/
 COPY BlazorApp1/BlazorApp1.Client/BlazorApp1.Client.csproj BlazorApp1/BlazorApp1.Client/
-RUN dotnet restore BlazorApp1/BlazorApp1.csproj
+RUN dotnet restore BlazorApp1/BlazorApp1/BlazorApp1.csproj
 COPY . .
 WORKDIR /src/BlazorApp1/BlazorApp1
 RUN dotnet publish BlazorApp1.csproj -c Release -o /app/publish


### PR DESCRIPTION
## Summary
- fix server project path in Dockerfile for proper build

## Testing
- `dotnet restore BlazorApp1/BlazorApp1/BlazorApp1.csproj`
- `dotnet publish BlazorApp1/BlazorApp1/BlazorApp1.csproj -c Release -o /tmp/publish`
- `dotnet --list-sdks`


------
https://chatgpt.com/codex/tasks/task_e_686251ab25d48323a137f34f0912e54c