### PR TITLE
Extend navbar container

### DIFF
--- a/BlazorApp1/BlazorApp1.Client/Layout/MainLayout.razor
+++ b/BlazorApp1/BlazorApp1.Client/Layout/MainLayout.razor
@@ -1,7 +1,7 @@
 ﻿@inherits LayoutComponentBase
 
 <div class="page">
-    <div class="navbar navbar-dark bg-dark navbar-expand-lg flex-column">
+    <div class="navbar navbar-dark bg-dark navbar-expand-lg flex-column sidebar">
         <NavMenu />
     </div>
 


### PR DESCRIPTION
## Summary
- ensure the navbar stretches to the bottom of the page on desktop by adding the `sidebar` class on the navbar container
- verify project builds with .NET 8

## Testing
- `dotnet build BlazorApp1.sln`

------
https://chatgpt.com/codex/tasks/task_e_68627f2f5c588323a1bc01c033aa6c80