### PR TITLE
Add date field and queue stats

### DIFF
--- a/BlazorApp1/BlazorApp1.Client/Models/QueueInfo.cs
+++ b/BlazorApp1/BlazorApp1.Client/Models/QueueInfo.cs
@@ -4,5 +4,6 @@ public class QueueInfo
 {
     public string QueueNumber { get; set; } = string.Empty;
     public string MfcNumber { get; set; } = string.Empty;
+    public string ApplicationDate { get; set; } = string.Empty;
     public string OrderNumber { get; set; } = string.Empty;
 }

--- a/BlazorApp1/BlazorApp1.Client/Models/SearchResponse.cs
+++ b/BlazorApp1/BlazorApp1.Client/Models/SearchResponse.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace BlazorApp1.Client.Models;
+
+public class SearchResponse
+{
+    public List<QueueInfo> Records { get; set; } = new();
+    public int TotalCount { get; set; }
+}

--- a/BlazorApp1/BlazorApp1.Client/Pages/Search.razor
+++ b/BlazorApp1/BlazorApp1.Client/Pages/Search.razor
@@ -23,11 +23,13 @@
 @if (Results?.Any() == true)
 {
     <div class="card p-4 mt-4">
+    <p>Общее количество заявлений в очереди: @TotalCount</p>
     <table class="table">
         <thead>
             <tr>
                 <th>Номер очереди</th>
                 <th>Номер МФЦ</th>
+                <th>Дата заявления</th>
                 <th>Номер распоряжения</th>
             </tr>
         </thead>
@@ -37,6 +39,7 @@
                 <tr>
                     <td>@item.QueueNumber</td>
                     <td>@item.MfcNumber</td>
+                    <td>@item.ApplicationDate</td>
                     <td>@item.OrderNumber</td>
                 </tr>
             }
@@ -73,6 +76,7 @@
     private string OrderNumber { get; set; } = string.Empty;
     private string MfcNumber { get; set; } = string.Empty;
     private List<QueueInfo>? Results;
+    private int TotalCount;
 
     private string ErrorMessage { get; set; } = string.Empty;
 
@@ -95,12 +99,14 @@
             if (!url.EndsWith("?")) url += "&";
             url += $"mfcNumber={Uri.EscapeDataString(MfcNumber)}";
         }
-        Results = await Http.GetFromJsonAsync<List<QueueInfo>>(url);
+        var response = await Http.GetFromJsonAsync<SearchResponse>(url);
+        Results = response?.Records;
+        TotalCount = response?.TotalCount ?? 0;
         if (Results == null || Results.Count == 0)
         {
             ErrorMessage = "Ничего не найдено";
         }
-        var dates = Results?.Select(r => r.OrderNumber).Distinct().ToList();
+        var dates = Results?.Select(r => r.ApplicationDate).Distinct().ToList();
         if (dates != null && dates.Count > 1)
         {
             DateOptions = dates;
@@ -110,7 +116,7 @@
 
     private void SelectDate(string date)
     {
-        Results = Results?.Where(r => r.OrderNumber == date).ToList();
+        Results = Results?.Where(r => r.ApplicationDate == date).ToList();
         ShowDateDialog = false;
         StateHasChanged();
     }

--- a/BlazorApp1/BlazorApp1/Controllers/SearchController.cs
+++ b/BlazorApp1/BlazorApp1/Controllers/SearchController.cs
@@ -1,5 +1,7 @@
 using BlazorApp1.Services;
+using BlazorApp1.Models;
 using Microsoft.AspNetCore.Mvc;
+using System.Linq;
 
 namespace BlazorApp1.Controllers;
 
@@ -15,9 +17,17 @@ public class SearchController : ControllerBase
     }
 
     [HttpGet]
-    public IActionResult Search([FromQuery] string? orderNumber, [FromQuery] string? mfcNumber)
+    public ActionResult<SearchResponse> Search([FromQuery] string? orderNumber, [FromQuery] string? mfcNumber)
     {
-        var records = _excel.Search(orderNumber, mfcNumber);
-        return Ok(records);
+        var records = _excel.Search(orderNumber, mfcNumber).ToList();
+        var max = _excel.Records
+            .Select(r => int.TryParse(r.QueueNumber, out var n) ? n : 0)
+            .DefaultIfEmpty(0)
+            .Max();
+        return new SearchResponse
+        {
+            Records = records,
+            TotalCount = max
+        };
     }
 }

--- a/BlazorApp1/BlazorApp1/Models/QueueInfo.cs
+++ b/BlazorApp1/BlazorApp1/Models/QueueInfo.cs
@@ -4,5 +4,6 @@ public class QueueInfo
 {
     public string QueueNumber { get; set; } = string.Empty;
     public string MfcNumber { get; set; } = string.Empty;
+    public string ApplicationDate { get; set; } = string.Empty;
     public string OrderNumber { get; set; } = string.Empty; // with date
 }

--- a/BlazorApp1/BlazorApp1/Models/SearchResponse.cs
+++ b/BlazorApp1/BlazorApp1/Models/SearchResponse.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace BlazorApp1.Models;
+
+public class SearchResponse
+{
+    public List<QueueInfo> Records { get; set; } = new();
+    public int TotalCount { get; set; }
+}

--- a/BlazorApp1/BlazorApp1/Services/ExcelDataService.cs
+++ b/BlazorApp1/BlazorApp1/Services/ExcelDataService.cs
@@ -49,8 +49,9 @@ public class ExcelDataService
         {
             var queue = row.Cell(1).GetString();
             var mfc = row.Cell(2).GetString();
-            var order = row.Cell(3).GetString();
-            if (ContainsPersonalData(queue) || ContainsPersonalData(mfc) || ContainsPersonalData(order))
+            var date = row.Cell(3).GetString();
+            var order = row.Cell(4).GetString();
+            if (ContainsPersonalData(queue) || ContainsPersonalData(mfc) || ContainsPersonalData(date) || ContainsPersonalData(order))
             {
                 return false;
             }
@@ -58,6 +59,7 @@ public class ExcelDataService
             {
                 QueueNumber = queue,
                 MfcNumber = mfc,
+                ApplicationDate = date,
                 OrderNumber = order
             });
         }


### PR DESCRIPTION
## Summary
- parse four columns from Excel including the application date
- expose total count of queue entries via search API
- show total count and new date column in search results
- add shared SearchResponse model

## Testing
- `dotnet build BlazorApp1.sln`

------
https://chatgpt.com/codex/tasks/task_e_68629a9bf8c08323a5f4e0fa0afa2beb