### PR TITLE
Show total application count on info page

### DIFF
--- a/BlazorApp1/BlazorApp1.Client/Pages/Info.razor
+++ b/BlazorApp1/BlazorApp1.Client/Pages/Info.razor
@@ -1,7 +1,20 @@
 @page "/"
+@inject HttpClient Http
+@using BlazorApp1.Client.Models
 
 <div class="card p-4">
     <h5 class="card-title">Общая информация</h5>
     <p>Это демонстрационное приложение для поиска данных по номерам распоряжений.</p>
-    @* <p>Для загрузки Excel используйте нашего <a href="https://t.me/example_bot" target="_blank">Telegram-бота</a>.</p> *@
+    <p>Общее количество заявлений в очереди: @TotalCount</p>
+    @* <p>Для загрузки Excel используем нашего <a href="https://t.me/example_bot" target="_blank">Telegram-бота</a>.</p> *@
 </div>
+
+@code {
+    private int TotalCount;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var response = await Http.GetFromJsonAsync<SearchResponse>("api/search");
+        TotalCount = response?.TotalCount ?? 0;
+    }
+}


### PR DESCRIPTION
## Summary
- fetch queue statistics on the Info page
- show total queue count immediately

## Testing
- `dotnet build BlazorApp1.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68629cfcf2a48323977e35bd5c0a186d