### PR TITLE
Fix search with trimmed inputs

### DIFF
--- a/BlazorApp1/BlazorApp1.Client/Pages/Search.razor
+++ b/BlazorApp1/BlazorApp1.Client/Pages/Search.razor
@@ -92,11 +92,11 @@
         }
         var url = "api/search?";
         if (!string.IsNullOrWhiteSpace(OrderNumber))
-            url += $"orderNumber={Uri.EscapeDataString(OrderNumber)}";
+            url += $"orderNumber={Uri.EscapeDataString(OrderNumber.Trim())}";
         if (!string.IsNullOrWhiteSpace(MfcNumber))
         {
             if (!url.EndsWith("?")) url += "&";
-            url += $"mfcNumber={Uri.EscapeDataString(MfcNumber)}";
+            url += $"mfcNumber={Uri.EscapeDataString(MfcNumber.Trim())}";
         }
         try
         {

--- a/BlazorApp1/BlazorApp1/Services/ExcelDataService.cs
+++ b/BlazorApp1/BlazorApp1/Services/ExcelDataService.cs
@@ -103,6 +103,7 @@ public class ExcelDataService
     private static string ExtractOrderDigits(string? value)
     {
         if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+        value = value.Trim();
         var match = Regex.Match(value, @"^\d+");
         return match.Success ? match.Value : string.Empty;
     }


### PR DESCRIPTION
## Summary
- ensure order number digits are extracted after trimming whitespace
- trim user inputs on the search page

## Testing
- `dotnet build BlazorApp1.sln -c Release`
- manual test with `curl` searching for an order number with leading space

------
https://chatgpt.com/codex/tasks/task_e_6862a250c78c83238f96a72d3ea42062