### PR TITLE
Display queue count on page load

### DIFF
--- a/BlazorApp1/BlazorApp1.Client/Pages/Search.razor
+++ b/BlazorApp1/BlazorApp1.Client/Pages/Search.razor
@@ -82,6 +82,18 @@
     private bool ShowDateDialog;
     private List<string> DateOptions = new();
 
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            TotalCount = await Http.GetFromJsonAsync<int>("api/search/count");
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = $"Не удалось получить количество: {ex.Message}";
+        }
+    }
+
     private async Task SearchAsync()
     {
         ErrorMessage = string.Empty;

--- a/BlazorApp1/BlazorApp1/Controllers/SearchController.cs
+++ b/BlazorApp1/BlazorApp1/Controllers/SearchController.cs
@@ -16,6 +16,12 @@ public class SearchController : ControllerBase
         _excel = excel;
     }
 
+    [HttpGet("count")]
+    public ActionResult<int> GetCount()
+    {
+        return _excel.GetTotalCount();
+    }
+
     [HttpGet]
     public ActionResult<SearchResponse> Search([FromQuery] string? orderNumber, [FromQuery] string? mfcNumber)
     {

--- a/BlazorApp1/BlazorApp1/Services/ExcelDataService.cs
+++ b/BlazorApp1/BlazorApp1/Services/ExcelDataService.cs
@@ -19,6 +19,14 @@ public class ExcelDataService
 
     public IReadOnlyList<QueueInfo> Records => _records;
 
+    public int GetTotalCount()
+    {
+        return _records
+            .Select(r => int.TryParse(r.QueueNumber, out var n) ? n : 0)
+            .DefaultIfEmpty(0)
+            .Max();
+    }
+
     public async Task<bool> LoadAsync(Stream stream)
     {
         using var ms = new MemoryStream();


### PR DESCRIPTION
## Summary
- add `GetTotalCount` to ExcelDataService
- expose `/api/search/count` endpoint
- fetch total count on `Search` page initialization
- install .NET 8

## Testing
- `dotnet build BlazorApp1.sln`
- `dotnet test BlazorApp1.sln`

------
https://chatgpt.com/codex/tasks/task_e_6862a466fd248323ae6c68551487493a