### PR TITLE
Fix order number layout on mobile

### DIFF
--- a/BlazorApp1/BlazorApp1.Client/Pages/Search.razor
+++ b/BlazorApp1/BlazorApp1.Client/Pages/Search.razor
@@ -22,7 +22,8 @@
 
 @if (Results?.Any() == true)
 {
-    <div class="card p-4 mt-4">    
+    <div class="card p-4 mt-4">
+    <div class="table-responsive">
     <table class="table">
         <thead>
             <tr>
@@ -44,6 +45,7 @@
             }
         </tbody>
     </table>
+    </div>
     </div>
 }
 

--- a/BlazorApp1/BlazorApp1.Client/Pages/Search.razor.css
+++ b/BlazorApp1/BlazorApp1.Client/Pages/Search.razor.css
@@ -1,0 +1,4 @@
+.table td {
+    word-break: break-word;
+    overflow-wrap: anywhere;
+}


### PR DESCRIPTION
## Summary
- keep long order numbers from overflowing card on mobile

## Testing
- `dotnet build reestr-svo.sln`

------
https://chatgpt.com/codex/tasks/task_e_686b921f8ae88323a828b0a81de5cbd4