### PR TITLE
Fix nav menu text wrapping

### DIFF
--- a/BlazorApp1/BlazorApp1.Client/Layout/NavMenu.razor.css
+++ b/BlazorApp1/BlazorApp1.Client/Layout/NavMenu.razor.css
@@ -29,6 +29,8 @@
 }
 
 .navbar-nav .nav-link {
+    display: flex;
+    align-items: flex-start;
     white-space: normal;
     word-break: break-word;
 }


### PR DESCRIPTION
## Summary
- adjust NavMenu CSS so wrapped text aligns under previous text instead of under the icon

## Testing
- `dotnet build reestr-svo.sln`

------
https://chatgpt.com/codex/tasks/task_e_686d0745529483238a704f1d65bc7430