### PR TITLE
Fix NavMenu text wrap indentation

### DIFF
--- a/BlazorApp1/BlazorApp1.Client/Layout/NavMenu.razor.css
+++ b/BlazorApp1/BlazorApp1.Client/Layout/NavMenu.razor.css
@@ -29,8 +29,16 @@
 }
 
 .navbar-nav .nav-link {
-    display: flex;
+    display: grid;
+    grid-template-columns: 1.25rem 1fr;
+    column-gap: 0.5rem;
     align-items: flex-start;
     white-space: normal;
     word-break: break-word;
+}
+
+/* Remove default margin from icons when used inside the navigation menu so that
+   text lines are indented from the left edge by the icon size when wrapping. */
+.navbar-nav .nav-link .bi {
+    margin-right: 0;
 }


### PR DESCRIPTION
## Summary
- ensure wrapped nav text is indented by the icon size

## Testing
- `dotnet build reestr-svo.sln`

------
https://chatgpt.com/codex/tasks/task_e_686d086d3ebc83238941360c39d6de58